### PR TITLE
feat: add PythonAnywhere WSGI wrapper for FastAPI

### DIFF
--- a/docs/superpowers/plans/2026-05-14-pythonanywhere-wrapper.md
+++ b/docs/superpowers/plans/2026-05-14-pythonanywhere-wrapper.md
@@ -1,0 +1,91 @@
+# PythonAnywhere Wrapper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a WSGI wrapper for the FastAPI backend using `a2wsgi` in `src/main.py` to support PythonAnywhere deployments.
+
+**Architecture:** Use `a2wsgi.ASGIMiddleware` to wrap the FastAPI ASGI application into a WSGI-compliant application object.
+
+**Tech Stack:** Python, FastAPI, a2wsgi.
+
+---
+
+### Task 1: Add a2wsgi wrapper to `src/main.py`
+
+**Files:**
+- Modify: `d4g-backend/src/main.py`
+
+- [ ] **Step 1: Add import and wrap app**
+
+```python
+# At the top of d4g-backend/src/main.py
+from a2wsgi import ASGIMiddleware
+
+# ... (existing imports and code)
+
+# At the bottom of d4g-backend/src/main.py
+app = create_app()
+
+# PythonAnywhere WSGI wrapper
+wsgi_app = ASGIMiddleware(app)
+```
+
+- [ ] **Step 2: Verify locally**
+
+Run: `uv run uvicorn src.main:app --reload`
+Expected: App starts and handles requests at http://localhost:8000.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add d4g-backend/src/main.py
+git commit -m "feat: add a2wsgi wrapper to src/main.py for PythonAnywhere support"
+```
+
+### Task 2: Update `wsgi.py` to use the wrapper from `src/main.py`
+
+**Files:**
+- Modify: `d4g-backend/wsgi.py`
+
+- [ ] **Step 1: Update wsgi.py to import from src.main**
+
+```python
+import os
+import sys
+
+# Add the current directory to sys.path so the 'src' package is discoverable
+path = os.path.dirname(os.path.abspath(__file__))
+if path not in sys.path:
+    sys.path.append(path)
+
+from src.main import wsgi_app as application
+
+# This 'application' object is what PythonAnywhere looks for in your configuration
+# It is now imported directly from src.main to keep the wrapper logic centralized.
+```
+
+- [ ] **Step 2: Verify by running a simple python script to check imports**
+
+Run: `python3 -c "from wsgi import application; print('WSGI application loaded successfully')"`
+Expected: Output "WSGI application loaded successfully".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add d4g-backend/wsgi.py
+git commit -m "refactor: update wsgi.py to use wsgi_app from src.main"
+```
+
+### Task 3: Final Verification
+
+- [ ] **Step 1: Run all backend tests**
+
+Run: `pytest d4g-backend/tests`
+Expected: All tests PASS.
+
+- [ ] **Step 2: Cleanup and Final Commit**
+
+```bash
+# Ensure everything is clean
+git status
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ dependencies = [
     "ruff>=0.1.0",
     "mypy>=1.5.0",
     "pytest-asyncio>=0.21.0",
+    "a2wsgi>=1.10.10",
 ]
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -124,3 +124,4 @@ gradio-client
 pdfplumber
 openai
 anthropic
+a2wsgi

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ import traceback
 from contextlib import asynccontextmanager
 from typing import Any
 
+from a2wsgi import ASGIMiddleware
 from fastapi import Cookie, Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -145,3 +146,6 @@ def create_app() -> FastAPI:
 
 
 app = create_app()
+
+# PythonAnywhere WSGI wrapper
+wsgi_app = ASGIMiddleware(app)

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,18 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "a2wsgi"
+version = "1.10.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/cb/822c56fbea97e9eee201a2e434a80437f6750ebcb1ed307ee3a0a7505b14/a2wsgi-1.10.10.tar.gz", hash = "sha256:a5bcffb52081ba39df0d5e9a884fc6f819d92e3a42389343ba77cbf809fe1f45", size = 18799, upload-time = "2025-06-18T09:00:10.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/d5/349aba3dc421e73cbd4958c0ce0a4f1aa3a738bc0d7de75d2f40ed43a535/a2wsgi-1.10.10-py3-none-any.whl", hash = "sha256:d2b21379479718539dc15fce53b876251a0efe7615352dfe49f6ad1bc507848d", size = 17389, upload-time = "2025-06-18T09:00:09.676Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -481,6 +493,7 @@ name = "d4g-backend"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "a2wsgi" },
     { name = "anthropic" },
     { name = "anyio" },
     { name = "asttokens" },
@@ -617,6 +630,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "a2wsgi", specifier = ">=1.10.10" },
     { name = "anthropic", specifier = ">=0.30.0" },
     { name = "anyio", specifier = ">=3.6.2" },
     { name = "asttokens", specifier = ">=2.0.5" },

--- a/wsgi.py
+++ b/wsgi.py
@@ -7,5 +7,7 @@ if path not in sys.path:
     sys.path.append(path)
 
 
+from src.main import wsgi_app as application  # noqa: F401
+
 # This 'application' object is what PythonAnywhere looks for in your configuration
 # It is now imported directly from src.main to keep the wrapper logic centralized.

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+# Add the current directory to sys.path so the 'src' package is discoverable
+path = os.path.dirname(os.path.abspath(__file__))
+if path not in sys.path:
+    sys.path.append(path)
+
+
+# This 'application' object is what PythonAnywhere looks for in your configuration
+# It is now imported directly from src.main to keep the wrapper logic centralized.


### PR DESCRIPTION
## Summary
- Implemented `a2wsgi` wrapper in `src/main.py` to support WSGI environments.
- Updated `wsgi.py` to import the centralized `wsgi_app` from `src/main`.
- Added `a2wsgi` to `requirements.txt` and verified with `uv`.

## Test Plan
- [x] Verified FastAPI app starts locally with `uv run uvicorn`.
- [x] Verified WSGI import works with `python -c "from wsgi import application"`.
- [x] All 43 integration and unit tests passed.